### PR TITLE
实现密码重置功能

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-Babel==0.9.6
 Flask==0.9
-Flask-Admin==1.0.4
 Flask-Babel==0.8
 Flask-Login==0.1.3
 Flask-OpenID==1.1.1
@@ -8,18 +6,7 @@ Flask-Principal==0.3.4
 Flask-SQLAlchemy==0.16
 Flask-Script==0.5.3
 Flask-WTF==0.8.3
-Jinja2==2.6
-Mako==0.7.3
-MarkupSafe==0.15
-MySQL-python==1.2.4
-SQLAlchemy==0.8.0
-WTForms==1.0.3
-Werkzeug==0.8.3
+Flask-Mail>=0.8.2
 alembic==0.4.2
-blinker==1.2
 markdown2==2.1.0
 mysql-connector-python==1.0.9
-python-openid==2.2.5
-pytz==2013b
-speaklater==1.3
-wsgiref==0.1.2

--- a/website/scriptfan/__init__.py
+++ b/website/scriptfan/__init__.py
@@ -11,6 +11,7 @@ from flask import Flask, render_template, abort, url_for, session
 from flask.ext.openid import OpenID
 from flask.ext.sqlalchemy import SQLAlchemy
 from flask.ext.login import LoginManager
+from flask_mail import Mail
 from flask.ext.babel import Babel
 from flask.ext.principal import Principal
 
@@ -20,6 +21,7 @@ db = SQLAlchemy()
 login_manager = LoginManager()
 babel = Babel()
 principals = Principal()
+mail = Mail()
 
 # Create flask application instance
 instance_path = os.path.abspath(os.path.dirname(__file__))
@@ -41,6 +43,7 @@ def config_app(app, config):
     oid.init_app(app)
     login_manager.init_app(app)
     babel.init_app(app)
+    mail.init_app(app)
 
     @app.after_request
     def after_request(response):

--- a/website/scriptfan/forms/user.py
+++ b/website/scriptfan/forms/user.py
@@ -48,6 +48,16 @@ class ResetStep1Form(RedirectForm):
             raise wtf.ValidationError(u'该邮件尚未在本站注册') 
 
 
+class ResetStep2Form(RedirectForm):
+    """ 接收密码重置邮件后重新填写密码 """
+
+    password = wtf.PasswordField(u'新密码', validators=[
+        wtf.Required(message=u'请填写新密码，不能少与5位字符'),
+        wtf.Length(min=5, max=20, message=u'密码应为5到20位字符')])
+    confirm = wtf.PasswordField(u'确认密码', validators=[
+        wtf.Required(message=u'请再次输入新密码'),
+        wtf.EqualTo('password', message=u'两次输入的密码不一致')])
+
 
 class SignupForm(RedirectForm):
     email = wtf.TextField('email', validators=[
@@ -91,7 +101,7 @@ class EditPasswordForm(RedirectForm):
         wtf.EqualTo('password', message=u'两次输入的密码不一致')])
 
     def validate_old_password(form, field):
-        # 当用户密码为空时，跳过原始密码验证，是否存在安全隐患？
+        # FIXME: 当用户密码为空时，跳过原始密码验证，是否存在安全隐患？
         if current_user.user.password and (not current_user.user.check_password(field.data)):
             raise wtf.ValidationError(u'提供的原始密码不正确')
 

--- a/website/scriptfan/forms/user.py
+++ b/website/scriptfan/forms/user.py
@@ -39,8 +39,14 @@ class ResetStep1Form(RedirectForm):
     email = wtf.TextField('email', validators=[
         wtf.Required(message=u'请填写电子邮件'),
         wtf.Email(message=u'无效的电子邮件')])
-    captcha = wtf.TextField('captcha', validators=[
-        wtf.Required(message=u'请填写验证码')])
+    # captcha = wtf.TextField('captcha', validators=[
+    #     wtf.Required(message=u'请填写验证码')])
+
+    def validate_email(form, field):
+        form.user = User.get_by_email(field.data)
+        if not form.user:
+            raise wtf.ValidationError(u'该邮件尚未在本站注册') 
+
 
 
 class SignupForm(RedirectForm):

--- a/website/scriptfan/forms/user.py
+++ b/website/scriptfan/forms/user.py
@@ -33,6 +33,15 @@ class SigninForm(RedirectForm):
         
         return not self.errors
 
+class ResetStep1Form(RedirectForm):
+    """请求发送密码重置邮件的表单"""
+
+    email = wtf.TextField('email', validators=[
+        wtf.Required(message=u'请填写电子邮件'),
+        wtf.Email(message=u'无效的电子邮件')])
+    captcha = wtf.TextField('captcha', validators=[
+        wtf.Required(message=u'请填写验证码')])
+
 
 class SignupForm(RedirectForm):
     email = wtf.TextField('email', validators=[

--- a/website/scriptfan/scriptfan.cfg.sample
+++ b/website/scriptfan/scriptfan.cfg.sample
@@ -23,3 +23,13 @@ BABEL_DEFAULT_LOCALE='zh_CN'
 
 # 密码盐，用于增加密码的安全性
 PASSWORD_SALT = 'udontkown@must#complicated'
+
+# 邮件设置
+MAIL_SERVER = 'your mail server'
+MAIL_PORT = 25
+MAIL_USE_TLS = False
+MAIL_USE_SSL = False
+MAIL_USERNAME = 'username' 
+MAIL_PASSWORD = 'password'
+MAIL_DEFAULT_SENDER = 'from@gmail.com'
+

--- a/website/scriptfan/templates/users/reset_email.html
+++ b/website/scriptfan/templates/users/reset_email.html
@@ -1,0 +1,11 @@
+{%- set reset_url = url_for('users.reset_step2', email=user.email, token=token, _external=True) -%}
+{%- set home_url = url_for('home.index', _external=True) -%}
+<strong>{{ user.nickname }}，你好！</strong>
+
+<p>请点击下面链接进行密码重置：</p>
+
+<a href="{{ reset_url }}">{{ reset_url }}</a>
+
+<hr />
+
+<p>想了解更多信息，请访问 <a href="{{ home_url }}">{{ home_url }}</a></p>

--- a/website/scriptfan/templates/users/reset_step1.html
+++ b/website/scriptfan/templates/users/reset_step1.html
@@ -17,6 +17,7 @@
                 <span class="help-inline">{{ form.email | error_text }}</span>
             </div>
         </div>
+        {#
         <div class="control-group {{ form.captcha | error_class }}">
             <label class="control-label">验证码</label>
             <div class="controls">
@@ -24,6 +25,7 @@
                 <span class="help-inline">{{ form.captcha | error_text }}</span>
             </div>
         </div>
+        #}
         <div class="form-actions">
             <button type="submit" class="btn btn-primary">发送电子邮件</button>
         </div>

--- a/website/scriptfan/templates/users/reset_step1.html
+++ b/website/scriptfan/templates/users/reset_step1.html
@@ -1,0 +1,33 @@
+{% extends "layout.html" %}
+
+{% block title %}{{ _('views.users.reset.title') }}{% endblock %}
+
+{% block content %}
+<div class="content">
+    <div class="page-header">
+        <h1>{{ self.title() }}</h1>
+    </div>
+    
+    <form action="{{ url_for('users.reset_step1') }}" class="form-horizontal" id="form-reset-step1" method="post">
+        {{ form.hidden_tag() }}
+        <div class="control-group {{ form.email | error_class }}">
+            <label class="control-label">电子邮件</label>
+            <div class="controls">
+                {{ form.email }}
+                <span class="help-inline">{{ form.email | error_text }}</span>
+            </div>
+        </div>
+        <div class="control-group {{ form.captcha | error_class }}">
+            <label class="control-label">验证码</label>
+            <div class="controls">
+                {{ form.captcha(class='input-small') }}
+                <span class="help-inline">{{ form.captcha | error_text }}</span>
+            </div>
+        </div>
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">发送电子邮件</button>
+        </div>
+    </form><!-- #form-signin -->
+</div><!-- .content -->
+{% endblock %}
+

--- a/website/scriptfan/templates/users/reset_step2.html
+++ b/website/scriptfan/templates/users/reset_step2.html
@@ -1,0 +1,35 @@
+{% extends "layout.html" %}
+
+{% block title %}{{ _('views.users.reset.title') }}{% endblock %}
+
+{% block content %}
+<div class="content">
+    <div class="page-header">
+        <h1>{{ self.title() }}</h1>
+    </div>
+    
+    <form action="{{ url_for('users.reset_step2') }}" class="form-horizontal" id="form-reset-step2" method="post">
+        {{ form.hidden_tag() }}
+        <div class="control-group {{ form.password | error_class }}">
+            <label class="control-label">新密码</label>
+            <div class="controls">
+                {{ form.password }}
+                <span class="help-inline">{{ form.password | error_text }}</span>
+            </div>
+        </div>
+
+        <div class="control-group {{ form.confirm | error_class }}">
+            <label class="control-label">确认密码</label>
+            <div class="controls">
+                {{ form.confirm }}
+                <span class="help-inline">{{ form.confirm | error_text }}</span>
+            </div>
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn btn-primary">修改密码</button>
+        </div>
+    </form><!-- #form-reset-step2 -->
+</div><!-- .content -->
+{% endblock %}
+

--- a/website/scriptfan/templates/users/signin.html
+++ b/website/scriptfan/templates/users/signin.html
@@ -22,6 +22,7 @@
             <div class="controls">
                 {{ form.password }}
                 <span class="help-inline">{{ form.password | error_text }}</span>
+                <span class="help-inline"><a href="{{ url_for('users.reset_step1') }}">忘记密码？</a></span>
             </div>
         </div>
         <div class="form-actions">

--- a/website/scriptfan/translations/zh_CN/LC_MESSAGES/messages.po
+++ b/website/scriptfan/translations/zh_CN/LC_MESSAGES/messages.po
@@ -31,6 +31,9 @@ msgstr "修改密码"
 msgid  "views.users.openids.title"
 msgstr "管理服务绑定"
 
+msgid  "views.users.reset.title"
+msgstr "重置密码"
+
 
 
 msgid "index"

--- a/website/scriptfan/views/articles.py
+++ b/website/scriptfan/views/articles.py
@@ -11,8 +11,10 @@ from flask import (Blueprint, render_template, redirect,
 from flask.ext import login
 from flask.ext.login import current_user
 from flask.ext.babel import gettext as _
+from flask_mail import Message
 
 from scriptfan import db
+from scriptfan import mail
 from scriptfan.functions import get_page, roles_required, require_roles
 from scriptfan.forms.base import RedirectForm
 from scriptfan.forms.articles import ArticleForm

--- a/website/scriptfan/views/users.py
+++ b/website/scriptfan/views/users.py
@@ -303,6 +303,7 @@ def _send_reset_email(user, token):
         app.logger.info('Sending reset email to %s with token %s', user.email, token)
         msg = Message(u'ScriptFan密码重置', recipients=[user.email])
         msg.html = render_template('users/reset_email.html', user=user, token=token)
+        # FIXME: 邮件发送使用异步方式，避免用户等待太长时间
         mail.send(msg)
         app.logger.info('Mail sent successfully.')
         return True

--- a/website/scriptfan/views/users.py
+++ b/website/scriptfan/views/users.py
@@ -11,7 +11,7 @@ from scriptfan import db, oid, login_manager
 from scriptfan.models import User, UserOpenID
 from scriptfan.forms.user import SignupForm, SigninForm, EditProfileForm, \
                                  EditPasswordForm, EditSlugForm, \
-                                 ManageOpenIDForm
+                                 ManageOpenIDForm, ResetStep1Form
 
 blurprint = Blueprint('users', __name__)
 
@@ -292,6 +292,10 @@ def slug():
     form.process(obj=current_user.user)
     return render_template('users/slug.html', form=form, skip_slug_info=True)
 
+@blurprint.route('/reset/step1', methods=['GET', 'POST'])
+def reset_step1():
+    form = ResetStep1Form()
+    return render_template('users/reset_step1.html', form=form)
 
 @blurprint.route('/password', methods=['GET', 'POST'])
 @login.login_required


### PR DESCRIPTION
还有一些需要改进的地方，我已经列在代码的 TODO 中了。
- [ ] 发件邮件时使用异步，避免用户等待
- [ ] 相关文字的国际化处理
- [ ] 重置密码成功后也要向用户发送确认邮件
- [ ] 改用 [flask-sendmail](http://flask-sendmail.readthedocs.org/en/latest/) 来发送邮件
